### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-enroute",
   "version": "0.0.1",
+  "repository": "tj/react-enroute",
   "description": "Small react router",
   "author": "TJ Holowaychuk <tj@tjholowaychuk.com>",
   "main": "build/index.js",


### PR DESCRIPTION
This removes a warning from `npm install` and repo shows up as a link on the npm page.
