### PR TITLE
Passing extra props to component

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,13 +36,13 @@ export class Router extends Component {
    */
 
   addRoute(el, parent) {
-    const { path, component, children } = el.props
+    const { path, component, children, ...elProps } = el.props
 
     assert(typeof path == 'string', `Route ${context(el.props)}is missing the "path" property`)
     assert(component, `Route ${context(el.props)}is missing the "component" property`)
 
     const render = (params, renderProps) => {
-      const finalProps = { ...this.props, ...renderProps, params }
+      const finalProps = { ...this.props, ...elProps, ...renderProps, params }
       const children = React.createElement(component, finalProps)
       return parent ? parent.render(params, { children }) : children
     }

--- a/index.js
+++ b/index.js
@@ -36,13 +36,13 @@ export class Router extends Component {
    */
 
   addRoute(el, parent) {
-    const { path, component, children, ...elProps } = el.props
+    const { path, component, children, ...routeProps } = el.props
 
     assert(typeof path == 'string', `Route ${context(el.props)}is missing the "path" property`)
     assert(component, `Route ${context(el.props)}is missing the "component" property`)
 
     const render = (params, renderProps) => {
-      const finalProps = { ...this.props, ...elProps, ...renderProps, params }
+      const finalProps = { ...this.props, ...routeProps, ...renderProps, params }
       const children = React.createElement(component, finalProps)
       return parent ? parent.render(params, { children }) : children
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 
-import React, { Component } from 'react'
+import React from 'react'
 import { Router, Route } from '..'
 import assert from 'assert-equal-jsx'
 
@@ -56,6 +56,10 @@ assert(<Router location="/list" items={["foo", "bar", "baz"]}>
 </Router>, <Index>
   <List items={["foo", "bar", "baz"]} />
 </Index>)
+
+assert(<Router location="/list">
+  <Route path="/list" component={List} items={["foo", "bar", "baz"]} />
+</Router>, <List items={["foo", "bar", "baz"]} />)
 
 // Nested route
 assert(<Router location="/pets">


### PR DESCRIPTION
fix #13 

Sometimes it's really useful. For example setting screen title in react-native:
```jsx
<Router>
  <Route ... title="Users" />
</Router>
```
Or certain configuration of component:
```jsx
<Router>
  <Route ... component={List} items={users} />
</Router>
```