### PR TITLE
React 16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,8 @@
     ]
   },
   "devDependencies": {
-    "assert-equal-jsx": "^1.0.3",
-    "react": "^15.0.0",
-    "react-dom": "^15.1.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-fatigue-dev": "github:tj/react-fatigue-dev"
   },
   "files": [
@@ -35,6 +34,6 @@
     "enroute": "^1.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
-
+import {equal} from 'assert'
 import React, { Component } from 'react'
+import {renderToStaticMarkup} from 'react-dom/server'
 import { Router, Route } from '..'
-import assert from 'assert-equal-jsx'
 
 function Index({ children }) {
   return <div>
@@ -146,3 +146,9 @@ assert(<Router location="/users/5/pets/2">
     </User>
   </Users>
 </Index>)
+
+function assert(actual, expected) {
+  actual = renderToStaticMarkup(actual);
+  expected = renderToStaticMarkup(expected);
+  equal(actual, expected);
+}


### PR DESCRIPTION
Fix #14.
Note: I removed `assert-equal-jsx` because it is not support React 16.
And @tj what do you think about me co-maintaining this package? I use it actively.